### PR TITLE
[add] Support POSITION_HOLD mode

### DIFF
--- a/src/uas/ArduPilotMegaMAV.cc
+++ b/src/uas/ArduPilotMegaMAV.cc
@@ -1389,6 +1389,9 @@ QString Copter::MessageFormatter::format(const ModeMessage &message)
     case Copter::ID_ATTITUDE:
         outputStream << "Attitude Identification";
         break;
+    case Copter::POS_HOLD:
+        outputStream << "Position Hold";
+        break;
     default:
         outputStream << "Unknown Mode:" << message.getMode();
         break;

--- a/src/uas/ArduPilotMegaMAV.h
+++ b/src/uas/ArduPilotMegaMAV.h
@@ -512,6 +512,7 @@ enum Mode {
     ATTITUDE_CTRL_RC = 28,
     ID_ACCEL_Z = 29,
     ID_ATTITUDE = 30,
+    POS_HOLD = 31,
     LAST_MODE
 };
 


### PR DESCRIPTION
Adds support for new `POSITION_HOLD` mode with identifier 31.
Here is the associated **autopilot_outdoor** PR: https://github.com/SquadroneSystem/autopilot_outdoor/pull/144.