### PR TITLE
[add] Support compass and attitude control failsafes

### DIFF
--- a/src/uas/ArduPilotMegaMAV.cc
+++ b/src/uas/ArduPilotMegaMAV.cc
@@ -1348,6 +1348,28 @@ QString Copter::MessageFormatter::format(const ErrorMessage &message)
         }
         break;
 
+    case 29:
+        outputStream << "FS-AttCtrl: ";
+        if (message.getErrorCode() == 1) {
+            outputStream << "raised";
+            EcodeUsed = true;
+        } else if (message.getErrorCode() == 0) {
+            outputStream << "resolved";
+            EcodeUsed = true;
+        }
+        break;
+    
+    case 30:
+        outputStream << "FS-Compass: ";
+        if (message.getErrorCode() == 1) {
+            outputStream << "raised";
+            EcodeUsed = true;
+        } else if (message.getErrorCode() == 0) {
+            outputStream << "resolved";
+            EcodeUsed = true;
+        }
+        break;
+
     default:
         outputStream << "SubSys:" << message.getSubsystemCode() << " ECode:" << message.getErrorCode();
         EcodeUsed = true;


### PR DESCRIPTION
# Pull Request Description

New identifiers of compass (30) and attitude control failsafe (29) are now supported.

- [x] This PR modifies `uas` directory.

See autopilot twin PR here: https://github.com/SquadroneSystem/autopilot_outdoor/pull/194.

## Manual Testing

- [x] The testing steps  1, 2, 3 (or more) below were followed

**Step 1: Simulation test**

New log identifiers are correctly interpreted.
![fix-subsystem-identifiers](https://github.com/user-attachments/assets/98f73521-8918-4ee9-9748-63bfeb590831)